### PR TITLE
fix: allow replacing stale entries left after crash

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -2,6 +2,9 @@ local S = minetest.get_translator("apartment")
 local gui = flow.widgets
 local p = {}
 
+local function isEqual(pos1, pos2)
+	return (pos1.x == pos2.x) and (pos1.y == pos2.y) and (pos1.z == pos2.z)
+end
 
 p.configure_gui = flow.make_gui(function(player, ctx)
 	local name = player:get_player_name()
@@ -124,7 +127,7 @@ p.configure_gui = flow.make_gui(function(player, ctx)
 							return
 						end
 
-						if apartment.apartments[category] and apartment.apartments[category][descr] then
+						if apartment.apartments[category] and apartment.apartments[category][descr] and (not isEqual(apartment.apartments[category][descr].pos, pos)) then
 							minetest.chat_send_player(name,
 								S("Error: The apartment @1@@@2 already exists. " ..
 								  "Please choose a different name or category.",

--- a/gui.lua
+++ b/gui.lua
@@ -2,10 +2,6 @@ local S = minetest.get_translator("apartment")
 local gui = flow.widgets
 local p = {}
 
-local function isEqual(pos1, pos2)
-	return (pos1.x == pos2.x) and (pos1.y == pos2.y) and (pos1.z == pos2.z)
-end
-
 p.configure_gui = flow.make_gui(function(player, ctx)
 	local name = player:get_player_name()
 	local pos = ctx.pos
@@ -127,7 +123,7 @@ p.configure_gui = flow.make_gui(function(player, ctx)
 							return
 						end
 
-						if apartment.apartments[category] and apartment.apartments[category][descr] and (not isEqual(apartment.apartments[category][descr].pos, pos)) then
+						if apartment.apartments[category] and apartment.apartments[category][descr] and not vector.equals(apartment.apartments[category][descr].pos, pos) then
 							minetest.chat_send_player(name,
 								S("Error: The apartment @1@@@2 already exists. " ..
 								  "Please choose a different name or category.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-apartment handling: duplicates are now allowed when they refer to the same on-panel location (enabling in-place updates) and only flagged as conflicts when an apartment with the same properties exists at a different position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->